### PR TITLE
datapath: Check for sock argument to v6ops->fragment.

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -398,7 +398,7 @@ AC_DEFUN([OVS_CHECK_LINUX_COMPAT], [
   OVS_GREP_IFELSE([$KSRC/include/linux/netfilter.h], [nf_hookfn.*nf_hook_ops],
                   [OVS_DEFINE([HAVE_NF_HOOKFN_ARG_OPS])])
   OVS_FIND_FIELD_IFELSE([$KSRC/include/linux/netfilter_ipv6.h], [nf_ipv6_ops],
-                        [fragment], [OVS_DEFINE([HAVE_NF_IPV6_OPS_FRAGMENT])])
+                        [fragment.*sock], [OVS_DEFINE([HAVE_NF_IPV6_OPS_FRAGMENT])])
 
   OVS_GREP_IFELSE([$KSRC/include/net/netfilter/nf_conntrack.h],
                   [tmpl_alloc.*conntrack_zone],


### PR DESCRIPTION
Ubuntu 3.13.0-83-generic has backported a patch that adds an intermediate
version of the v6ops->fragment function that doesn't seem to ever been
part of a released upstream kernel. This version is missing the sock
argument to the fragment function.

Since we already have a backported version of the function from a newer
kernel, this simply ignores the version that Ubuntu is now making available
and continues to use the OVS version, similar to what it was doing before.

Reported-by: Zoltán Balogh zoltan.balogh@ericsson.com
Reported-by: Aaron Rosen aaronorosen@gmail.com
Reported-by: Russell Bryant russell@ovn.org
Signed-off-by: Jesse Gross jesse@kernel.org
Acked-by: Russell Bryant russell@ovn.org
