### PR TITLE
allow dkms build+install to fail

### DIFF
--- a/debian/openvswitch-datapath-dkms.postinst
+++ b/debian/openvswitch-datapath-dkms.postinst
@@ -15,7 +15,7 @@ if [ "x${isadded}" = "x" ] ; then
 fi
 
 if [ "$1" = 'configure' ] ; then
-        dkms build -m "$name" -v "$version" && dkms install -m "$name" -v "$version"
+        dkms build -m "$name" -v "$version" && dkms install -m "$name" -v "$version" || true
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
that `|| true` was originally present but was removed to ensure the ovs upgrade failed as early as possible.