### PR TITLE
stt: do not use udp fragmentation offload

### DIFF
--- a/datapath/actions.c
+++ b/datapath/actions.c
@@ -756,10 +756,6 @@ static void do_output(struct datapath *dp, struct sk_buff *skb, int out_port,
 {
 	struct vport *vport = ovs_vport_rcu(dp, out_port);
 
-	if (!skb_is_gso(skb) && !mru) {
-		OVS_CB(skb)->mru = vport->dev->mtu;
-	}
-
 	if (likely(vport)) {
 		u16 mru = OVS_CB(skb)->mru;
 

--- a/datapath/datapath.h
+++ b/datapath/datapath.h
@@ -97,7 +97,7 @@ struct datapath {
  * struct ovs_skb_cb - OVS data in skb CB
  * @input_vport: The original vport packet came in on. This value is cached
  * when a packet is received by OVS.
- * @mru: The maximum received fragement size; 0 if the packet is not
+ *mru: The maximum received fragement size; 0 if the packet is not
  * fragmented.
  */
 struct ovs_skb_cb {


### PR DESCRIPTION
UFO has been deprecated due to complexity and security concerns in the kernel:
https://www.spinics.net/lists/netdev/msg443815.html

https://jira.internal.digitalocean.com/browse/SYS-615

[will update with a more thorough description]