### PR TITLE
datapath: stt: process frag list if skipping zero copy

### DIFF
--- a/datapath/linux/compat/stt.c
+++ b/datapath/linux/compat/stt.c
@@ -523,6 +523,7 @@ static int coalesce_skb(struct sk_buff **headp)
 static int coalesce_skb(struct sk_buff **headp)
 {
 	struct sk_buff *frag, *head, *next;
+	int err;
 
 	err = straighten_frag_list(headp);
 	if (unlikely(err))
@@ -530,7 +531,6 @@ static int coalesce_skb(struct sk_buff **headp)
 	head = *headp;
 
 	int delta = FRAG_CB(head)->first.tot_len - skb_headlen(head);
-	int err;
 
 	if (unlikely(!head->next))
 		return 0;


### PR DESCRIPTION
It seems frag_list isn't addressed at all in the coalesce_skb() code path with the SKIP_ZERO_COPY directive defined.

In stt_rcv, straighten and normalize frag lists then attempt to coalesce before proceeding