### PR TITLE
Various 2.11.3 reboot fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+openvswitch (2.11.3-0digitalocean2) bionic; urgency=medium
+
+  * d/{openvswitch-switch,ovsdb-server,ovs-vswitchd}.service: bringup
+    OVS after networking.service
+  * d/openvswitch-switch.service: OVS is a requirement for
+    network-online-digitalocean.service
+  * d/openvswitch-switch.service: bring up/down br0 on start/start
+
+ -- Nishanth Aravamudan <naravamudan@digitalocean.com>  Wed, 24 Jul 2020 14:33:41 -0500
+
 openvswitch (2.11.3-0digitalocean1) bionic; urgency=medium
 
   * New upstream release (2.11.3)

--- a/debian/openvswitch-switch.ovs-vswitchd.service
+++ b/debian/openvswitch-switch.ovs-vswitchd.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Open vSwitch Forwarding Unit
-After=ovsdb-server.service network-pre.target systemd-udev-settle.service
-Before=network.target networking.service
+After=ovsdb-server.service systemd-udev-settle.service networking.service
 Requires=ovsdb-server.service
 ReloadPropagatedFrom=ovsdb-server.service
 AssertPathIsReadWrite=/var/run/openvswitch/db.sock

--- a/debian/openvswitch-switch.ovsdb-server.service
+++ b/debian/openvswitch-switch.ovsdb-server.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Open vSwitch Database Unit
-After=syslog.target network-pre.target dpdk.service
-Before=network.target networking.service
+After=syslog.target dpdk.service networking.service
 PartOf=openvswitch-switch.service
 DefaultDependencies=no
 

--- a/debian/openvswitch-switch.service
+++ b/debian/openvswitch-switch.service
@@ -5,6 +5,8 @@ PartOf=network.target
 Requires=ovsdb-server.service
 Requires=ovs-vswitchd.service
 Requires=networking.service
+Before=network-online-digitalocean.service
+RequiredBy=network-online-digitalocean.service
 
 [Service]
 Type=oneshot

--- a/debian/openvswitch-switch.service
+++ b/debian/openvswitch-switch.service
@@ -10,9 +10,9 @@ RequiredBy=network-online-digitalocean.service
 
 [Service]
 Type=oneshot
-ExecStart=/bin/true
+ExecStart=/sbin/ifup --allow=ovs br0
 ExecReload=/usr/share/openvswitch/scripts/ovs-systemd-reload
-ExecStop=/bin/true
+ExecStop=/sbin/ifdown --allow=ovs br0
 RemainAfterExit=yes
 
 [Install]

--- a/debian/openvswitch-switch.service
+++ b/debian/openvswitch-switch.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=Open vSwitch
-Before=network.target
-After=network-pre.target ovsdb-server.service ovs-vswitchd.service
+After=ovsdb-server.service ovs-vswitchd.service networking.service
 PartOf=network.target
 Requires=ovsdb-server.service
 Requires=ovs-vswitchd.service
+Requires=networking.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
While 2.11.3-0digitalocean1 successfully live updates, upon reboot, we see long delays in networking.service (which times out after 5 minutes). Initially, we thought switching the br0 stanza in /e/n/i to auto was the correct method, but that is what actually causes this delay. Upon investigation into the ordering in the prior version of OVS (2.11.2...) packaging, it's clear from the logs that networking.service runs *before* openvswitch-switch.service (via the sysvinit file) and openvswitch-switch.service is responsible for first starting its dependent services (via ovs-ctl) and then bringing up the bridge itself. Mimic this in our systemd-only world.