### PR TITLE
Fix service file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+openvswitch (2.11.3-0digitalocean3) bionic; urgency=medium
+
+  * d/openvswitch-switch.service: correct systemd service RequiredBy
+    line.
+
+ -- Nishanth Aravamudan <naravamudan@digitalocean.com>  Fri, 26 Jun 2020 13:56:38 -0500
+
 openvswitch (2.11.3-0digitalocean2) bionic; urgency=medium
 
   * d/{openvswitch-switch,ovsdb-server,ovs-vswitchd}.service: bringup

--- a/debian/openvswitch-switch.service
+++ b/debian/openvswitch-switch.service
@@ -6,7 +6,6 @@ Requires=ovsdb-server.service
 Requires=ovs-vswitchd.service
 Requires=networking.service
 Before=network-online-digitalocean.service
-RequiredBy=network-online-digitalocean.service
 
 [Service]
 Type=oneshot
@@ -17,3 +16,4 @@ RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target
+RequiredBy=network-online-digitalocean.service


### PR DESCRIPTION
RequiredBy must be in the Install section.

Before this change:

```
# systemd-analyze verify /lib/systemd/system/openvswitch-switch.service
/lib/systemd/system/openvswitch-switch.service:9: Unknown lvalue 'RequiredBy' in section 'Unit'
Attempted to remove disk file system, and we can't allow that.
```

After:

```
# systemd-analyze verify /lib/systemd/system/openvswitch-switch.service
Attempted to remove disk file system, and we can't allow that.
```